### PR TITLE
fixes for GITOPS-1281, GITOPS-1282, and GITOPS-1283

### DIFF
--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsDetails.tsx
@@ -14,17 +14,12 @@ import {
 import { GitAltIcon } from '@patternfly/react-icons';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-// import { routeDecoratorIcon } from '@console/dev-console/src/components/import/render-utils';
 import { ExternalLink, Timestamp } from '@console/internal/components/utils';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ConsoleLinkModel } from '@console/internal/models';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
-import {
-  GreenCheckCircleIcon,
-  YellowExclamationTriangleIcon,
-  GrayUnknownIcon,
-} from '@console/shared';
 import { GitOpsEnvironment } from '../utils/gitops-types';
+import GitOpsRenderStatusLabel from './GitOpsRenderStatusLabel';
 import GitOpsResourcesSection from './GitOpsResourcesSection';
 import './GitOpsDetails.scss';
 
@@ -45,32 +40,6 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName }) => {
     (link: K8sResourceKind) =>
       link.metadata?.name === 'argocd' && link.spec?.location === 'ApplicationMenu',
   );
-
-  // eslint-disable-next-line no-shadow
-  const renderStatusLabel = (status: string) => {
-    switch (status) {
-      case 'Synced':
-        return (
-          <Label icon={<GreenCheckCircleIcon />} isTruncated>
-            Synced
-          </Label>
-        );
-      case 'OutOfSync':
-        return (
-          <Label icon={<YellowExclamationTriangleIcon />} isTruncated>
-            OutOfSync
-          </Label>
-        );
-      case 'Unknown':
-        return (
-          <Label icon={<GrayUnknownIcon />} isTruncated>
-            Unknown
-          </Label>
-        );
-      default:
-        return '';
-    }
-  };
 
   let oldAPI = false;
   if (envs && envs.length > 0) {
@@ -126,7 +95,7 @@ const GitOpsDetails: React.FC<GitOpsDetailsProps> = ({ envs, appName }) => {
                       {env.status && (
                         <StackItem className="odc-gitops-details__env-section__status-label">
                           <Tooltip content="Sync status">
-                            <span>{renderStatusLabel(env.status)}</span>
+                            <GitOpsRenderStatusLabel status={env.status} />
                           </Tooltip>
                         </StackItem>
                       )}

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsRenderStatusLabel.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsRenderStatusLabel.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Label } from '@patternfly/react-core';
+import {
+  GreenCheckCircleIcon,
+  YellowExclamationTriangleIcon,
+  GrayUnknownIcon,
+} from '@console/shared';
+
+interface GitOpsRenderStatusLabelProps {
+  status: string;
+}
+
+const GitOpsRenderStatusLabel: React.FC<GitOpsRenderStatusLabelProps> = ({ status }) => {
+  switch (status) {
+    case 'Synced':
+      return (
+        <Label icon={<GreenCheckCircleIcon />} isTruncated>
+          Synced
+        </Label>
+      );
+    case 'OutOfSync':
+      return (
+        <Label icon={<YellowExclamationTriangleIcon />} isTruncated>
+          OutOfSync
+        </Label>
+      );
+    case 'Unknown':
+      return (
+        <Label icon={<GrayUnknownIcon />} isTruncated>
+          Unknown
+        </Label>
+      );
+    default:
+      return null;
+  }
+};
+
+export default GitOpsRenderStatusLabel;

--- a/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.tsx
+++ b/frontend/packages/gitops-plugin/src/components/details/GitOpsResourcesSection.tsx
@@ -28,11 +28,18 @@ interface GitOpsResourcesSectionProps {
   clusterRoleBindings: GitOpsHealthResources[];
 }
 
+export enum HealthStatus {
+  DEGRADED = 'Degraded',
+  PROGRESSING = 'Progressing',
+  MISSING = 'Missing',
+  UNKNOWN = 'Unknown',
+}
+
 const getUnhealthyResources = () => (acc: string[], current: GitOpsHealthResources): string[] =>
-  current.health === 'Degraded' ||
-  current.health === 'Progressing' ||
-  current.health === 'Missing' ||
-  current.health === 'Unknown'
+  current.health === HealthStatus.DEGRADED ||
+  current.health === HealthStatus.PROGRESSING ||
+  current.health === HealthStatus.MISSING ||
+  current.health === HealthStatus.UNKNOWN
     ? [...acc, current.health]
     : acc;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/GITOPS-1281- removed one line, I'm not sure it was needed there anyway because it didn't give me any errors when I removed it. 

https://issues.redhat.com/browse/GITOPS-1282- moved `renderStatusLabel` out of `GitOpsResourcesSection` but still in the same file. Looking at the review comment made originally I wasn't sure if it meant to keep it in the same file or give it it's own file. It's not that long, so I thought keeping in the same file would be okay. 

https://issues.redhat.com/browse/GITOPS-1283- made `HealthStatus` into an enum and using that now instead in `getUnhealthyResources`